### PR TITLE
Add fixing method

### DIFF
--- a/Julia/Modules/BSpline.jl
+++ b/Julia/Modules/BSpline.jl
@@ -18,12 +18,6 @@ struct Knots
     function Knots(vector)
         new(sort(vector))
     end
-    function Knots(i::Int)
-        if i ≠ 0
-            error("Knots(0) is only alllowed")
-        end
-        return Knots([])
-    end
 end
 
 Base.zero(::Type{Knots}) = Knots([])

--- a/Julia/Modules/_InitialConfiguration.jl
+++ b/Julia/Modules/_InitialConfiguration.jl
@@ -8,6 +8,7 @@ function InitialConfiguration(D;n₁=15,nip=NIP)
     mkpath(DIR*"/strain")
     mkpath(DIR*"/colorbar")
     mkpath(DIR*"/slack")
+    mkpath(DIR*"/output")
 
     D₁,D₂=D
     M=InitBs(D,n₁,nip=nip)

--- a/Julia/Modules/_NewtonRaphsonMethod.jl
+++ b/Julia/Modules/_NewtonRaphsonMethod.jl
@@ -1,7 +1,33 @@
 using Dates
 
+function DefaultOrientation(n₁,n₂)
+    return (
+        [(n₁+1)÷2,(n₂+1)÷2,1],
+        [(n₁+1)÷2,(n₂+1)÷2,2],
+        [(n₁+1)÷2,(n₂+1)÷2-1,1]
+    )
+end
+
+function FixThreePoints(n₁,n₂)
+    return (
+        [1,(n₂+1)÷2,1],
+        [1,(n₂+1)÷2,2],
+        [(n₁+1)÷2,(n₂+1)÷2,1],
+        [(n₁+1)÷2,(n₂+1)÷2,2],
+        [n₁,(n₂+1)÷2,1],
+        [n₁,(n₂+1)÷2,2]
+    )
+end
+
 export NewtonMethodIteration
-function NewtonMethodIteration(;fixed=((n₁,n₂)->([(n₁+1)÷2,(n₂+1)÷2,1],[(n₁+1)÷2,(n₂+1)÷2,2],[(n₁+1)÷2,(n₂+1)÷2-1,1])),parent=0,nip=NIP)
+function NewtonMethodIteration(;fixingmethod=:DefaultOrientation,parent=0,nip=NIP)
+    if fixingmethod == :DefaultOrientation
+        fixed = DefaultOrientation
+    elseif fixingmethod == :FixThreePoints
+        fixed = FixThreePoints
+    else
+        error("No method for $(fixingmethod)")
+    end
     parent=Parent(parent)
     M=loadM(index=parent)
 


### PR DESCRIPTION
You can choose control points fixing method in optional argument `fixingmethod` in `NewtonMethodItteration`.
The candidates for the argument are:
* `:DefaultOrientation`
* `FixThreePoints`